### PR TITLE
Allow API key to be set by yaml config.

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,7 +1,12 @@
 <?php
 
-if(defined('SS_RAYGUN_APP_KEY')) {
-	$raygun = new RaygunLogWriter(SS_RAYGUN_APP_KEY);
+$raygunAPIKey = Config::inst()->get('RaygunLogWriter', 'api_key');
+if(empty($raygunAPIKey) && defined('SS_RAYGUN_APP_KEY')) {
+	$raygunAPIKey = SS_RAYGUN_APP_KEY;
+}
+
+if(!empty($raygunAPIKey)) {
+	$raygun = new RaygunLogWriter($raygunAPIKey);
 	SS_Log::add_writer($raygun, SS_Log::WARN, '<=');
 	register_shutdown_function(array($raygun, 'shutdown_function'));
 } else {

--- a/code/RaygunLogWriter.php
+++ b/code/RaygunLogWriter.php
@@ -4,6 +4,12 @@ require_once BASE_PATH . '/vendor/autoload.php';
 require_once THIRDPARTY_PATH . '/Zend/Log/Writer/Abstract.php';
 
 class RaygunLogWriter extends Zend_Log_Writer_Abstract {
+	/**
+	 * @config
+	 * @var string The API Key for your application, given on the Raygun 'Application Settings' page
+	 */
+	private static $api_key;
+
 	protected $client;
 	protected $postException;
 


### PR DESCRIPTION
This change means that the Raygun API key can be set in two different ways:
1. Firstly, it checks your YAML configuration for the api_key value to be set on RaygunLogWriter.
2. If it can't find that, it will look for the SS_RAYGUN_APP_KEY define, which can be set in your _ss_environment.php (this was the previous default behaviour).
   1. Note that it will only search in SS_RAYGUN_APP_KEY if it can't find the YAML configuration value first.
