### PR TITLE
Moved session user ID to write() call

### DIFF
--- a/code/RaygunLogWriter.php
+++ b/code/RaygunLogWriter.php
@@ -15,14 +15,14 @@ class RaygunLogWriter extends Zend_Log_Writer_Abstract {
 
 	function __construct($appKey) {
 		$this->client = new \Raygun4php\RaygunClient($appKey);
+	}
 
+	function _write($message) {
 		// keep track of the current user (if available) so we can identify it in Raygun
 		if(Member::currentUserID()) {
 			$this->client->SetUser(Member::currentUser()->Email);
 		}
-	}
 
-	function _write($message) {
 		// Reverse-engineer the SilverStripe-repackaged exception
 		if(preg_match('/^Uncaught ([A-Za-z0-9_]+):(.*)$/', $message['message']['errstr'], $matches)
 				&& ($matches[1] == 'Exception' || is_subclass_of($matches[1], 'Exception'))) {


### PR DESCRIPTION
More accurate reading (e.g. for errors on Security/LoginForm POST requests),
but also avoids cases where DB::getConn() is used before its initialized.
That's the case when a user has "Remmber me" set, in which case
Member::currentUserID() will trigger a Convert::raw2sql() call that
relies on a valid database object to perform its escaping.
