### PR TITLE
Use Injector to create RaygunLogWriter. Allows swapping out the class.

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -6,7 +6,7 @@ if(empty($raygunAPIKey) && defined('SS_RAYGUN_APP_KEY')) {
 }
 
 if(!empty($raygunAPIKey)) {
-	$raygun = new RaygunLogWriter($raygunAPIKey);
+	$raygun = Injector::inst()->create('RaygunLogWriter', $raygunAPIKey);
 	$levelConfig = Config::inst()->get('RaygunLogWriter', 'level');
 	$level = defined($levelConfig) ? constant($levelConfig) : SS_Log::WARN;
 	SS_Log::add_writer($raygun, $level, '<=');

--- a/code/RaygunLogWriter.php
+++ b/code/RaygunLogWriter.php
@@ -52,8 +52,8 @@ class RaygunLogWriter extends Zend_Log_Writer_Abstract {
 		}
 	}
 
-	static function factory($config) {
-		return new RaygunLogWriter($config['app_key']);
+	public static function factory($config) {
+		return Injector::inst()->create('RaygunLogWriter', $config['app_key']);
 	}
 
 	function exception_handler($exception) {


### PR DESCRIPTION
Allows for customisation of RaygunLogWriter by dependency injection. Currently this class is hardcoded to "RaygunLogWriter" which means you can't override it.

RaygunLogWriter is only instantiated once per-request, so it shouldn't introduce any performance impact using Injector.
