### PR TITLE
Remove unused namespaces from RaygunClientFactory

### DIFF
--- a/src/RaygunClientFactory.php
+++ b/src/RaygunClientFactory.php
@@ -3,9 +3,6 @@
 namespace SilverStripe\Raygun;
 
 use SilverStripe\Core\Injector\Factory;
-use SilverStripe\Security\Member;
-use SilverStripe\Control\Session;
-use Graze\Monolog\Handler\RaygunHandler;
 use Raygun4php\RaygunClient;
 
 class RaygunClientFactory implements Factory


### PR DESCRIPTION
Unless I'm missing something (quite possible here), these namespaces aren't used in this context. 