### PR TITLE
FIX: Unable to access the CMS if no raygun key is set

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -2,11 +2,16 @@
 Name: raygun
 ---
 SilverStripe\Core\Injector\Injector:
-  Psr\Log\LoggerInterface:
-    calls:
-      - [ pushHandler, [ %$SilverStripe\Raygun\RaygunHandler ]]
   SilverStripe\Raygun\RaygunHandler:
     constructor:
       RaygunClient: %$Raygun4php\RaygunClient
   Raygun4php\RaygunClient:
     factory: 'SilverStripe\Raygun\RaygunClientFactory'
+---
+Only:
+  envorconstant: 'SS_RAYGUN_APP_KEY'
+---
+SilverStripe\Core\Injector\Injector:
+  Psr\Log\LoggerInterface:
+    calls:
+      - [ pushHandler, [ %$SilverStripe\Raygun\RaygunHandler ]]


### PR DESCRIPTION
Address #24 - If no `SS_RAYGUN_APP_KEY` is defined then accessing the CMS etc dies hard. Shifting the RaygunHandler to only push into the logger if the env var is set fixes this.