### PR TITLE
Make it a silverstripe-vendor module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "silverstripe/raygun",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "description": "RayGun.io integration for SilverStripe",
-    "homepage": "http://github.com/silverstripe-labs/silverstripe-raygun",
+    "homepage": "http://github.com/silverstripe/silverstripe-raygun",
     "license": "BSD-3-Clause",
     "keywords": ["silverstripe", "raygun", "logging"],
     "authors": [


### PR DESCRIPTION
### What this PR does / why we need it:

Update the composer.json in silverstripe-raygun to change the type to **silverstripe-vendormodule** and set the current _homepage url_ to prevent one tiny redirect from the silverstripe-labs namespace.

### What changed / what was implemented:
- Updated the composer.json file