### PR TITLE
DOCS: mistake in readme (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You can define the error reporting level in your YAML config:
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Raygun\RaygunHandler:
     constructor:
+      client: '%$Raygun4php\RaygunClient'
       level: 'error'
 ```
 


### PR DESCRIPTION
The documentation description will break the application because the level is a second param in the constructor not the first.