### PR TITLE
NEW: Upgrade to monolog-extensions 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,10 @@
         }
     ],
     "require": {
+        "php": ">=5.6.0",
         "mindscape/raygun4php": "^1",
         "silverstripe/framework": "^4.0",
-        "graze/monolog-extensions": "^1.6"
+        "graze/monolog-extensions": "^2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is necessary to fix some bugs that prevent non-error log messages
from being set in SilverStripe 4.0 - 4.3.

I've tested locally and it doesn't appear as though the major release breaks the APIs we're using.

Once this is merged I'd like to tag a 2.2.0 release.

This fixes #42