### PR TITLE
Disable user tracking by default in RaygunClient

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,8 +1,10 @@
 ---
 Name: raygun
 ---
-### Disable Raygun user tracking to improve performance through caching ###
-SilverStripe\Raygun\disableUserTracking: true
+# Setting to disable Raygun user tracking.
+# Avoids setting a cookie and hence improve performance
+Raygun4php\RaygunClient:
+  disable_user_tracking: true
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Raygun\RaygunHandler:
     constructor:

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,6 +1,7 @@
 ---
 Name: raygun
 ---
+SilverStripe\Raygun\disableUserTracking: false
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Raygun\RaygunHandler:
     constructor:

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,7 +1,8 @@
 ---
 Name: raygun
 ---
-SilverStripe\Raygun\disableUserTracking: false
+### Disable Raygun user tracking to improve performance through caching ###
+SilverStripe\Raygun\disableUserTracking: true
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Raygun\RaygunHandler:
     constructor:

--- a/src/RaygunClientFactory.php
+++ b/src/RaygunClientFactory.php
@@ -33,7 +33,7 @@ class RaygunClientFactory implements Factory
         // extract api key from .env file
         $apiKey = (string) Environment::getEnv(self::RAYGUN_APP_KEY_NAME);
         $disableTracking = Config::inst()->get(
-            'SilverStripe\Raygun\disableUserTracking'
+            RaygunClient::class, 'disable_user_tracking'
         );
         $disableTracking = is_bool($disableTracking) ? $disableTracking : false;
 

--- a/src/RaygunClientFactory.php
+++ b/src/RaygunClientFactory.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Raygun;
 
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Factory;
 use SilverStripe\Core\Environment;
 use Raygun4php\RaygunClient;
@@ -31,6 +32,11 @@ class RaygunClientFactory implements Factory
     {
         // extract api key from .env file
         $apiKey = (string) Environment::getEnv(self::RAYGUN_APP_KEY_NAME);
+        $disableTracking = Config::inst()->get(
+            'SilverStripe\Raygun\disableUserTracking'
+        );
+        $disableTracking = is_bool($disableTracking) ? $disableTracking : false;
+
 
         // log error to warn user that exceptions will not be logged to Raygun
         if (empty($apiKey)) {
@@ -39,7 +45,12 @@ class RaygunClientFactory implements Factory
         }
 
         // setup new client
-        $this->client = new RaygunClient($apiKey);
+        $this->client = new RaygunClient(
+            $apiKey,
+            true,
+            false,
+            $disableTracking
+        );
 
         $this->filterSensitiveData();
 

--- a/src/RaygunHandler.php
+++ b/src/RaygunHandler.php
@@ -2,16 +2,24 @@
 
 namespace SilverStripe\Raygun;
 
-use SilverStripe\Security\Member;
+use SilverStripe\Core\Config\Config;
 use Graze\Monolog\Handler\RaygunHandler as MonologRaygunHandler;
+use SilverStripe\Security\Security;
 
 class RaygunHandler extends MonologRaygunHandler
 {
     protected function write(array $record)
     {
-        $member = Member::currentUser();
-        if ($member) {
-            $this->client->SetUser($member->Email);
+        $disableTracking = Config::inst()->get(
+            'SilverStripe\Raygun\disableUserTracking'
+        );
+        $disableTracking = is_bool($disableTracking) ? $disableTracking : false;
+
+        if (!$disableTracking) {
+            $user = Security::getCurrentUser();
+            if ($user) {
+                $this->client->SetUser($user->Email);
+            }
         }
 
         parent::write($record);

--- a/src/RaygunHandler.php
+++ b/src/RaygunHandler.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Raygun;
 
+use Raygun4php\RaygunClient;
 use SilverStripe\Core\Config\Config;
 use Graze\Monolog\Handler\RaygunHandler as MonologRaygunHandler;
 use SilverStripe\Security\Security;
@@ -11,7 +12,7 @@ class RaygunHandler extends MonologRaygunHandler
     protected function write(array $record)
     {
         $disableTracking = Config::inst()->get(
-            'SilverStripe\Raygun\disableUserTracking'
+            RaygunClient::class, 'disable_user_tracking'
         );
         $disableTracking = is_bool($disableTracking) ? $disableTracking : false;
 


### PR DESCRIPTION
This change allows to disable the user tracking in _RaygunClient_, which means no user information will be sent to Raygun (and therefore it will not report the affected users per error).
This is to avoid setting a cookie on every instantiation and allow proper caching on a CDN level (performance).

In addition to that, Security::getCurrentUser is used instead of Member::getCurrentUser to avoid using deprecated methods.