### PR TITLE
Add name for config

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -12,6 +12,7 @@ SilverStripe\Core\Injector\Injector:
   Raygun4php\RaygunClient:
     factory: 'SilverStripe\Raygun\RaygunClientFactory'
 ---
+Name: defaultraygunloggerhandler
 Only:
   envorconstant: 'SS_RAYGUN_APP_KEY'
 ---


### PR DESCRIPTION
This commit should fix the issue described in https://github.com/silverstripe/silverstripe-raygun/issues/30, which blocks overrides in custom configuration.