### PR TITLE
Add missing getPrevious() method to ReportedException

### DIFF
--- a/code/RaygunLogWriter.php
+++ b/code/RaygunLogWriter.php
@@ -157,4 +157,7 @@ class ReportedException {
 	function getLine() {
 		return $this->data['errline'];
 	}
+	function getPrevious() {
+		return null;
+	}
 }


### PR DESCRIPTION
RaygunExceptionMessage calls getPrevious on the supplied exception. As this method doesn't exist on ReportedException, the process is broken.