### PR TITLE
NEW Filter out more potentially sensitive vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ Raygun will send the following data:
 By default we filter out some sensitive SilverStripe details which appear in the $_SERVER variable. These include:
 
 - SS_DATABASE_USERNAME
-- SS_DATABASE_PASSWORD
 - SS_DEFAULT_ADMIN_USERNAME
-- SS_DEFAULT_ADMIN_PASSWORD
 - SS_RAYGUN_APP_KEY
+- Cookie information (through `Cookie` and `HTTP_COOKIE`)
+- Basic auth information (through `PHP_AUTH_PW`)
+- HTTP authorisation information (through `Authorization` and `HTTP_AUTHORIZATION`)
+- Anything containing `_PASSWORD`, `_KEY` or `_TOKEN`
 
 You will likely want to filter out other sensitive data such as credit cards, passwords etc. You can do this in your `mysite/_config.php` file. These rules are applied to $_SERVER, $_POST and $_GET data. All key comparisons are case insensitive.
 

--- a/src/RaygunClientFactory.php
+++ b/src/RaygunClientFactory.php
@@ -51,9 +51,11 @@ class RaygunClientFactory implements Factory
         // Filter sensitive data out of server variables
         $this->client->setFilterParams([
             '/SS_DATABASE_USERNAME/' => true,
-            '/SS_DATABASE_PASSWORD/' => true,
             '/SS_DEFAULT_ADMIN_USERNAME/' => true,
-            '/SS_DEFAULT_ADMIN_PASSWORD/' => true,
+            '/KEY/i' => true,
+            '/TOKEN/i' => true,
+            '/PASSWORD/i' => true,
+            '/SECRET/i' => true,
             sprintf('/%s/', self::RAYGUN_APP_KEY_NAME) => true,
             '/HTTP_AUTHORIZATION/' => true,
             '/PHP_AUTH_PW/' => true,


### PR DESCRIPTION
This is technically an API change,
but if you really wanted to include those,
setFilterParams() can be used to remove those additional filters.
In 99% of cases, values for those keys weren't meant to be leaked
to third party systems such as Raygun.