### PR TITLE
ENH Allow configuration of what user data is sent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ SilverStripe\Core\Injector\Injector:
       level: 'error'
 ```
 
+#### User tracking
+
+By default, no user data will be sent to Raygun at all. You can choose to track logged-in members by setting some yml configuration:
+
+```yml
+---
+After: raygun
+---
+Raygun4php\RaygunClient:
+  disable_user_tracking: false
+
+SilverStripe\Raygun\RaygunHandler:
+  user_main_id_field: 'ID' #default: 'Email'. This is the "Identifier" in the Raygun app.
+  user_include_firstname: true #default: false
+  user_include_fullname: true #default: false
+  user_include_email: true #default: false
+```
+
 #### Multiple Raygun API Keys (app keys)
 
 You may have more than one Raygun integration, each of which could use custom API keys, different

--- a/src/RaygunHandler.php
+++ b/src/RaygunHandler.php
@@ -5,10 +5,21 @@ namespace SilverStripe\Raygun;
 use Raygun4php\RaygunClient;
 use SilverStripe\Core\Config\Config;
 use Graze\Monolog\Handler\RaygunHandler as MonologRaygunHandler;
+use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Security\Security;
 
 class RaygunHandler extends MonologRaygunHandler
 {
+    use Configurable;
+
+    private static $user_main_id_field = 'Email';
+
+    private static $user_include_firstname = false;
+
+    private static $user_include_fullname = false;
+
+    private static $user_include_email = false;
+
     protected function write(array $record)
     {
         $disableTracking = Config::inst()->get(
@@ -20,7 +31,13 @@ class RaygunHandler extends MonologRaygunHandler
         if (!$disableTracking) {
             $user = Security::getCurrentUser();
             if ($user) {
-                $this->client->SetUser($user->Email);
+                $idField = $this->config()->get('user_main_id_field');
+                $this->client->SetUser(
+                    (string)$user->$idField,
+                    (bool)$this->config()->get('user_include_firstname') ? $user->FirstName : null,
+                    (bool)$this->config()->get('user_include_fullname') ? $user->getName() : null,
+                    (bool)$this->config()->get('user_include_email') ? $user->Email : null
+                );
             }
         }
 


### PR DESCRIPTION
Currently the only configuration regarding user (`Member`) data is whether to send it at all or not - and only the email address can be sent.

This pull request provides configuration options for what `Member` data is sent.