### PR TITLE
ENH: Provide a way to conditionally disable the raygun handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,48 @@ SilverStripe\Core\Injector\Injector:
       - [ pushHandler, [ '%$SilverStripe\Raygun\RaygunHandler.custom'] ]
 ```
 
+#### Disable handler
+
+The RaygunHandler is enabled by default when the `SS_RAYGUN_APP_KEY` environment variable is set. There may be some situations where you need that variable to be set but you don't want the handler enabled by default (e.g. you may not want the handler enabled in dev or test environments except when triggering some test exception via a `BuildTask`).
+
+```yml
+---
+Only:
+  environment: 'dev'
+---
+SilverStripe\Raygun\RaygunHandler:
+  enabled: false
+```
+
+Then in your `BuildTask` you can enable that handler as required.
+
+```php
+use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\Raygun\RaygunHandler;
+
+class TriggerTestExtensionTask extends BuildTask
+{
+    protected $title = 'Trigger Test Exception';
+
+    protected $description = 'Throws an exception. Useful for checking raygun integration is working as expected.';
+
+    /**
+     * Throw a test exception that is directed through raygun.
+     *
+     * @param HTTPRequest $request
+     */
+    public function run($request)
+    {
+        $env = Director::get_environment_type();
+        Config::modify()->set(RaygunHandler::class, 'enabled', true);
+        throw new \Exception("Test exception thrown from '$env' environment.");
+    }
+}
+```
+
 #### Proxy
 
 If you need to forward outgoing requests through a proxy (such as for sites hosted in CWP), you can set the proxy host and optional port via yaml config:

--- a/src/RaygunHandler.php
+++ b/src/RaygunHandler.php
@@ -19,9 +19,15 @@ class RaygunHandler extends MonologRaygunHandler
     private static $user_include_fullname = false;
 
     private static $user_include_email = false;
+	
+    private static $enabled = true;
 
     protected function write(array $record)
     {
+        if (!(bool)$this->config()->get('enabled')) {
+            return;
+        }
+
         $disableTracking = Config::inst()->get(
             RaygunClient::class,
             'disable_user_tracking'


### PR DESCRIPTION
There are situations where it may be useful to have the `SS_RAYGUN_APP_KEY` environment variable set without automatically sending all exceptions to Raygun.

In particular, we have a use case where we don't want errors sent to raygun in our test and QA environments usually, but we want to be able to run a `BuildTask` to trigger an exception that does get sent to raygun in those environments as a quick test that changes we have made do what we expect them to in regards to error monitoring.