### PR TITLE
FIX use correct argument name for setting client in handler.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -8,7 +8,7 @@ Raygun4php\RaygunClient:
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Raygun\RaygunHandler:
     constructor:
-      RaygunClient: '%$Raygun4php\RaygunClient'
+      client: '%$Raygun4php\RaygunClient'
   Raygun4php\RaygunClient:
     factory: 'SilverStripe\Raygun\RaygunClientFactory'
 ---


### PR DESCRIPTION
`RaygunClient` is not the correct parameter name for the constructor argument - using it can cause the client to be passed in as the level if the level is overridden following the readme documentation (with the addition of setting `After: raygun`) which results in `Object of class Raygun4php\RaygunClient could not be converted to int`