### PR TITLE
ENH support raygun4php SDK v2

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -1,0 +1,8 @@
+---
+Name: raygun-cache
+---
+SilverStripe\Core\Injector\Injector:
+  Psr\SimpleCache\CacheInterface.raygunCache:
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: "raygunCache"

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     "require": {
         "php": ">=7.1",
         "mindscape/raygun4php": "^1",
-        "silverstripe/framework": "^4.3",
-        "graze/monolog-extensions": "^2"
+        "silverstripe/framework": "^4.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "mindscape/raygun4php": "^1",
+        "mindscape/raygun4php": "^1 || ^2",
         "silverstripe/framework": "^4.3"
     },
     "autoload": {

--- a/src/RaygunFormatter.php
+++ b/src/RaygunFormatter.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * This file was originally part of Monolog Extensions
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Nature Delivered Ltd. <http://graze.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @see  http://github.com/graze/MonologExtensions/blob/master/LICENSE
+ * @link http://github.com/graze/MonologExtensions
+ */
+
+namespace SilverStripe\Raygun;
+
+use Monolog\Formatter\NormalizerFormatter;
+
+class RaygunFormatter extends NormalizerFormatter
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param  array $record A record to format
+     *
+     * @return mixed The formatted record
+     */
+    public function format(array $record)
+    {
+        $record = parent::format($record);
+
+        $record['tags'] = [];
+        $record['custom_data'] = [];
+        $record['timestamp'] = null;
+
+        foreach (['extra', 'context'] as $source) {
+            if (array_key_exists('tags', $record[$source]) && is_array($record[$source]['tags'])) {
+                $record['tags'] = array_merge($record['tags'], $record[$source]['tags']);
+            }
+            if (array_key_exists('timestamp', $record[$source]) && is_numeric($record[$source]['timestamp'])) {
+                $record['timestamp'] = $record[$source]['timestamp'];
+            }
+            unset($record[$source]['tags'], $record[$source]['timestamp']);
+        }
+
+        $record['custom_data'] = $record['extra'];
+        $record['extra'] = [];
+        foreach ($record['context'] as $key => $item) {
+            if (!in_array($key, ['file', 'line', 'exception'])) {
+                $record['custom_data'][$key] = $item;
+                unset($record['context'][$key]);
+            }
+        }
+
+        return $record;
+    }
+}

--- a/src/RaygunHandler.php
+++ b/src/RaygunHandler.php
@@ -1,14 +1,43 @@
 <?php
+/*
+ * The bulk of this file was originally part of Monolog Extensions
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Nature Delivered Ltd. <http://graze.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @see  http://github.com/graze/MonologExtensions/blob/master/LICENSE
+ * @link http://github.com/graze/MonologExtensions
+ */
 
 namespace SilverStripe\Raygun;
 
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
 use Raygun4php\RaygunClient;
 use SilverStripe\Core\Config\Config;
-use Graze\Monolog\Handler\RaygunHandler as MonologRaygunHandler;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Security\Security;
 
-class RaygunHandler extends MonologRaygunHandler
+class RaygunHandler extends AbstractProcessingHandler
 {
     use Configurable;
 
@@ -19,21 +48,42 @@ class RaygunHandler extends MonologRaygunHandler
     private static $user_include_fullname = false;
 
     private static $user_include_email = false;
-	
+
     private static $enabled = true;
 
+    /**
+     * @var RaygunClient
+     */
+    protected $client;
+
+    /**
+     * @param RaygunClient $client
+     * @param int          $level
+     * @param bool         $bubble
+     */
+    public function __construct(RaygunClient $client, $level = Logger::DEBUG, $bubble = true)
+    {
+        $this->client = $client;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @param array $record
+     */
     protected function write(array $record)
     {
+        // If not enabled, don't write anything.
         if (!(bool)$this->config()->get('enabled')) {
             return;
         }
 
+        // Set user tracking and data.
         $disableTracking = Config::inst()->get(
             RaygunClient::class,
             'disable_user_tracking'
         );
         $disableTracking = is_bool($disableTracking) ? $disableTracking : false;
-
         if (!$disableTracking) {
             $user = Security::getCurrentUser();
             if ($user) {
@@ -47,6 +97,67 @@ class RaygunHandler extends MonologRaygunHandler
             }
         }
 
-        parent::write($record);
+        // Write exceptions and errors appropriately.
+        $context = $record['context'];
+        if (isset($context['exception'])
+            && (
+                $context['exception'] instanceof \Exception
+                || (PHP_VERSION_ID > 70000 && $context['exception'] instanceof \Throwable)
+            )
+        ) {
+            $this->writeException(
+                $record,
+                $record['formatted']['tags'],
+                $record['formatted']['custom_data'],
+                $record['formatted']['timestamp']
+            );
+        } elseif (isset($context['file']) && isset($context['line'])) {
+            $this->writeError(
+                $record['formatted'],
+                $record['formatted']['tags'],
+                $record['formatted']['custom_data'],
+                $record['formatted']['timestamp']
+            );
+        }
+        // do nothing if its not an exception or an error
+    }
+
+    /**
+     * @param array     $record
+     * @param array     $tags
+     * @param array     $customData
+     * @param int|float $timestamp
+     */
+    protected function writeError(array $record, array $tags = [], array $customData = [], $timestamp = null)
+    {
+        $context = $record['context'];
+        $this->client->SendError(
+            0,
+            $record['message'],
+            $context['file'],
+            $context['line'],
+            $tags,
+            $customData,
+            $timestamp
+        );
+    }
+
+    /**
+     * @param array     $record
+     * @param array     $tags
+     * @param array     $customData
+     * @param int|float $timestamp
+     */
+    protected function writeException(array $record, array $tags = [], array $customData = [], $timestamp = null)
+    {
+        $this->client->SendException($record['context']['exception'], $tags, $customData, $timestamp);
+    }
+
+    /**
+     * @return \Monolog\Formatter\FormatterInterface
+     */
+    protected function getDefaultFormatter()
+    {
+        return new RaygunFormatter();
     }
 }


### PR DESCRIPTION
Fixes #59 

This PR provides support for raygun4php sdk V2 while allowing anyone who for whatever reason might want/need to stay on sdk V1 (e.g. super old PHP versions) to keep up to date with this module.

The only breaking changes that I can see for sdk V2 vs V1 are in the constructor so I think this should be safe.
I have tried both versions of the SDK with this PR and have had no issues with either.