### PR TITLE
Bug: Fix for invalid argument type provided to writeError()

### DIFF
--- a/src/RaygunHandler.php
+++ b/src/RaygunHandler.php
@@ -106,7 +106,7 @@ class RaygunHandler extends AbstractProcessingHandler
             );
         } elseif (isset($context['file']) && isset($context['line'])) {
             $this->writeError(
-                $formatted,
+                $record,
                 $formatted['tags'],
                 $formatted['custom_data'],
                 $formatted['timestamp']


### PR DESCRIPTION
Fixes #71
Closes #71

Tested on a live environment. I'm no longer getting instances of the errors from #71 